### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -76,6 +76,16 @@
       });
     });
 
+    test('assign object - should not pollute prototype', function () {
+      var obj1 = {};
+      var obj2 = JSON.parse('{"__proto__": {"polluted": true}}');
+
+      var result = nx.deepAssign(obj1, obj2);
+
+      expect(result).toEqual({});
+      expect({}.polluted).toBe(undefined);
+    });
+
     test('proxy agent will not deep mixed', () => {
       var options = {
         method: 'post',

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@
     nx.forIn(inSrc, function (key, value) {
       var type = toString.call(value);
       switch (true) {
-        case isPlainObject(value):
+        case isPlainObject(value) && !isPrototypePolluted(key):
           inTarget[key] = inTarget[key] || {};
           assign(inTarget[key], value);
           break;
@@ -22,6 +22,10 @@
           break;
       }
     });
+  }
+
+  function isPrototypePolluted(key) {
+    return /__proto__|constructor|prototype/.test(key);
   }
 
   nx.deepAssign = function (inTarget) {


### PR DESCRIPTION
### :bar_chart: Metadata *

`@jswork/next-deep-assign` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40jswork%2Fnext-deep-assign

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var nextDeepAssign = require("@jswork/next-deep-assign")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
nextDeepAssign(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @jswork/next-deep-assign # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105159171-c961f800-5b34-11eb-87f5-cc89c3c9a4fa.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
